### PR TITLE
Export utility types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### What's changed
 
 - Remove the need for marking a mapping dependency `as const`
+- Export type helpers to get the registrations and type of the systemic
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export type { Systemic, Component } from "./types";
+export type { Systemic, Component, RegistrationsOf, TypeOf } from "./types";
 export { systemic } from "./systemic";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { Component, ComponentTypeOf, DependenciesOf, IsComponent } from "./component";
 export type { AsRegistrations, Definition, Registration } from "./definition";
 export type { DependsOnOption } from "./dependencies";
-export type { ComponentsOf, SystemOf } from "./system";
+export type { ComponentsOf, SystemOf, RegistrationsOf, TypeOf } from "./system";
 export type { Systemic, SystemicBuild } from "./systemic";
 export type { EmptyObject } from "./util";

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -1,4 +1,5 @@
 import type { Registration } from "./definition";
+import type { Systemic } from "./systemic";
 import type { EmptyObject, SetNestedProp, UnionToTuple } from "./util";
 
 // Build the system type from the system definition
@@ -24,3 +25,17 @@ type BuildSystem<
 export type ComponentsOf<TSystem extends Record<string, Registration>> = {
   [K in keyof TSystem]: TSystem[K]["component"];
 };
+
+/**
+ * Extract the registration type from a Systemic type
+ */
+export type RegistrationsOf<TSystem extends Systemic<any>> = TSystem extends Systemic<infer T>
+  ? T
+  : never;
+
+/**
+ * Extract the component types from a Systemic type
+ */
+export type TypeOf<TSystem extends Systemic<any>> = TSystem extends Systemic<infer T>
+  ? SystemOf<T>
+  : never;

--- a/test/types/system.spec.ts
+++ b/test/types/system.spec.ts
@@ -1,20 +1,55 @@
-import type { Registration, SystemOf } from "../../src/types";
+import type { Registration, RegistrationsOf, Systemic, SystemOf, TypeOf } from "../../src/types";
 import { expectTypes } from "../test-helpers/type-matchers";
 
 describe("system types", () => {
-  it("is the type of the system defined by the given definition", () => {
-    type Definition = {
-      foo: Registration<{ foo: string }>;
-      bar: Registration<number>;
-      "baz.qux": Registration<{ qux: boolean }>;
-      "baz.quux": Registration<string>;
-    };
+  describe("SystemOf", () => {
+    it("is the type of the system defined by the given definition", () => {
+      type Definition = {
+        foo: Registration<{ foo: string }>;
+        bar: Registration<number>;
+        "baz.qux": Registration<{ qux: boolean }>;
+        "baz.quux": Registration<string>;
+      };
 
-    type System = SystemOf<Definition>;
+      type System = SystemOf<Definition>;
 
-    expectTypes<
-      System,
-      { foo: { foo: string }; bar: number; baz: { qux: { qux: boolean }; quux: string } }
-    >().toBeEqual();
+      expectTypes<
+        System,
+        { foo: { foo: string }; bar: number; baz: { qux: { qux: boolean }; quux: string } }
+      >().toBeEqual();
+    });
+  });
+
+  describe("RegistrationsOf", () => {
+    it("extracts the registration type from a Systemic type", () => {
+      type Definition = {
+        foo: Registration<{ foo: string }>;
+        bar: Registration<number>;
+        "baz.qux": Registration<{ qux: boolean }>;
+        "baz.quux": Registration<string>;
+      };
+
+      type System = Systemic<Definition>;
+
+      expectTypes<RegistrationsOf<System>, Definition>().toBeEqual();
+    });
+  });
+
+  describe("TypeOf", () => {
+    it("extracts the component types from a Systemic type", () => {
+      type Definition = {
+        foo: Registration<{ foo: string }>;
+        bar: Registration<number>;
+        "baz.qux": Registration<{ qux: boolean }>;
+        "baz.quux": Registration<string>;
+      };
+
+      type System = Systemic<Definition>;
+
+      expectTypes<
+        TypeOf<System>,
+        { foo: { foo: string }; bar: number; baz: { qux: { qux: boolean }; quux: string } }
+      >().toBeEqual();
+    });
   });
 });


### PR DESCRIPTION
Fixes #20

Exports some helper types from the module. These helpers are very useful in some edge cases, but in most situations usage is discouraged:
- RegistrationsOf can be used when working with subsystems, but it's usually better to just specify the required dependencies on the main system explicitly. Over use of this type can use to Infinite debt issues.
- TypeOf can be used to get the type of the built system, but we should encourage the use of async/await patterns rather than callbacks and in such situations we usually don't need to specify the type.

Since the types are easy to find when you need them, I did not add them to the documentation.

- [x] Tests pass
- [] Appropriate changes to README are included in PR
